### PR TITLE
日付型の修正

### DIFF
--- a/cmd/sqlite/query/create.go
+++ b/cmd/sqlite/query/create.go
@@ -21,7 +21,7 @@ func Create(tableName string, columns []types.Column, options ...func(any)) (str
 
 	body := []string{}
 	for _, column := range columns {
-		body = append(body, fmt.Sprintf("`%s` %s NOT NULL", column.Name, column.Type))
+		body = append(body, fmt.Sprintf("`%s` %s NOT NULL", column.Name, column.Type.AsSQL()))
 	}
 	if len(o.PrimaryKey) > 0 {
 		keys := []string{}

--- a/cmd/sqlite/query/insert.go
+++ b/cmd/sqlite/query/insert.go
@@ -64,8 +64,8 @@ func cast(column types.Column, value string) (string, error) {
 		}
 		return fmt.Sprintf(`%g`, v), nil
 	case types.ColumnTypeDateTime:
-		if _, err := time.Parse(time.RFC3339, value); err == nil {
-			return fmt.Sprintf(`"%s"`, value), nil
+		if v, err := time.Parse(time.RFC3339, value); err == nil {
+			return fmt.Sprintf(`%d`, v.Unix()), nil
 		}
 		// タイムゾーンが含まれないフォーマットの場合、コンフィグに基づきタイムゾーンを設定
 		if v, err := time.Parse("2006-01-02 15:04:05", value); err == nil {
@@ -73,7 +73,7 @@ func cast(column types.Column, value string) (string, error) {
 			v = v.In(&loc)
 			_, offset := v.Zone()
 			v = v.Add(time.Duration(offset) * -time.Second)
-			return fmt.Sprintf(`"%s"`, v.Format(time.RFC3339)), nil
+			return fmt.Sprintf(`%d`, v.Unix()), nil
 		}
 		return fmt.Sprintf(`"%s"`, value), nil
 	default:

--- a/cmd/sqlite/types/column.go
+++ b/cmd/sqlite/types/column.go
@@ -28,3 +28,14 @@ func ColumnType(v string) columnType {
 		return ColumnTypeText
 	}
 }
+
+func (c columnType) AsSQL() string {
+	switch c {
+	case ColumnTypeInteger, ColumnTypeDateTime:
+		return "INTEGER"
+	case ColumnTypeNumeric:
+		return "NUMERIC"
+	default:
+		return "TEXT"
+	}
+}


### PR DESCRIPTION
- SQLite でテーブル定義時のカラム型を DateTime とした場合
  - 内部的には Numeric 型として定義される
  - そのカラムに対してデータを格納する際に値が文字列だった場合、フォーマットによって挙動が異なる

以上の仕様から、SQLite では日付型を扱うのは難しいため、Integer 型にする

- SQLite 仕様
  - https://www.sqlite.org/datatype3.html#date_and_time_datatype